### PR TITLE
Switching to builder pattern, removing unnecessary test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM alpine:latest AS builder
 
 LABEL org.opencontainers.image.source https://github.com/tijjjy/Tailscale-DERP-Docker
 
-#Install Tailscale and requirements
-RUN apk add curl iptables
-
 #Install GO and Tailscale DERPER
 RUN apk add go --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN go install tailscale.com/cmd/derper@main
 
 FROM alpine:latest
+
+#Install Tailscale requirements
+RUN apk add curl iptables
 
 #Install Tailscale and Tailscaled
 RUN apk add tailscale --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN apk add curl iptables
 RUN apk add go --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN go install tailscale.com/cmd/derper@main
 
+FROM alpine:latest
+
 #Install Tailscale and Tailscaled
 RUN apk add tailscale --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
-
-FROM alpine:latest
 
 RUN mkdir -p /root/go/bin
 COPY --from=builder /root/go/bin/derper /root/go/bin/derper

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:latest AS builder
 
 LABEL org.opencontainers.image.source https://github.com/tijjjy/Tailscale-DERP-Docker
 
@@ -11,6 +11,11 @@ RUN go install tailscale.com/cmd/derper@main
 
 #Install Tailscale and Tailscaled
 RUN apk add tailscale --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+
+FROM alpine:latest
+
+RUN mkdir -p /root/go/bin
+COPY --from=builder /root/go/bin/derper /root/go/bin/derper
 
 #Copy init script
 COPY init.sh /init.sh

--- a/init.sh
+++ b/init.sh
@@ -5,10 +5,7 @@
 /usr/bin/tailscale up --accept-routes=true --accept-dns=true --auth-key $TAILSCALE_AUTH_KEY >> /dev/stdout &
 
 #Check for and or create certs directory
-if [[ ! -d "/root/derper/$TAILSCALE_DERP_HOSTNAME" ]]
-then
-    mkdir -p /root/derper/$TAILSCALE_DERP_HOSTNAME
-fi
+mkdir -p /root/derper/$TAILSCALE_DERP_HOSTNAME
 
 #Start Tailscale derp server
 /root/go/bin/derper --hostname $TAILSCALE_DERP_HOSTNAME --bootstrap-dns-names $TAILSCALE_DERP_HOSTNAME -certmode $TAILSCALE_DERP_CERTMODE -certdir /root/derper/$TAILSCALE_DERP_HOSTNAME --stun --verify-clients=$TAILSCALE_DERP_VERIFY_CLIENTS


### PR DESCRIPTION
I've switched the Dockerfile to use the "builder pattern" so that the resulting docker image can be smaller (you aren't carrying around the build dependencies, only the resulting executable).

Also "mkdir -p directory" does not need to be protected by an "if [ ! -d directory ]", because it is a NOOP if the directory already exists.