### PR TITLE
Use Ubuntu as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,47 @@
-FROM alpine:latest AS builder
+# Use Ubuntu as the base image for the builder
+FROM ubuntu:latest AS builder
 
 LABEL org.opencontainers.image.source https://github.com/tijjjy/Tailscale-DERP-Docker
 
-#Install GO and Tailscale DERPER
-RUN apk add go --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+# Install dependencies and the latest Go
+RUN apt-get update && \
+    apt-get install -y wget tar && \
+    wget https://go.dev/dl/go1.21.4.linux-amd64.tar.gz && \
+    tar -xvf go1.21.4.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set Go environment variables
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOROOT="/usr/local/go"
+
+# Install Tailscale DERPER
 RUN go install tailscale.com/cmd/derper@main
 
-FROM alpine:latest
+# Use Ubuntu as the final base image
+FROM ubuntu:latest
 
-#Install Tailscale requirements
-RUN apk add curl iptables
+# Install Tailscale requirements
+RUN apt-get update && \
+    apt-get install -y curl iptables && \
+    rm -rf /var/lib/apt/lists/*
 
-#Install Tailscale and Tailscaled
-RUN apk add tailscale --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+# Install Tailscale
+RUN curl -fsSL https://tailscale.com/install.sh | sh
 
+# Create the necessary directory and copy the derper binary
 RUN mkdir -p /root/go/bin
 COPY --from=builder /root/go/bin/derper /root/go/bin/derper
 
-#Copy init script
+# Copy and set permissions for the init script
 COPY init.sh /init.sh
 RUN chmod +x /init.sh
 
-#Derper Web Ports
+# Derper Web Ports
 EXPOSE 80
 EXPOSE 443/tcp
-#STUN
+# STUN
 EXPOSE 3478/udp
 
-ENTRYPOINT /init.sh
+ENTRYPOINT ["/init.sh"]
+


### PR DESCRIPTION
Use ubuntu as the base image as it allows installing tailscale from the script provided by them which also means that the latest version of tailscaled can be installed on the system vs waiting for the package repos to up their version of tailscaled. I tried installing from the script on alpine and it was missing lots of dependencies, hence the move to ubuntu.